### PR TITLE
Fix slcan command and make it usable with slcand and ip commands.

### DIFF
--- a/doggie_core/src/lib.rs
+++ b/doggie_core/src/lib.rs
@@ -230,7 +230,7 @@ where
                         }
                     }
                     SlcanCommand::FilterId(id) => can.set_filter(id),
-                    SlcanCommand::FilterMask(mask) => can.set_filter(mask),
+                    SlcanCommand::FilterMask(mask) => can.set_mask(mask),
                     SlcanCommand::SetBitrate(bitrate) => {
                         can.set_bitrate(can::CanBitrates::from(bitrate as u16))
                     }

--- a/doggie_core/src/mcp2515.rs
+++ b/doggie_core/src/mcp2515.rs
@@ -54,10 +54,6 @@ impl<SPI: SpiDevice> CanDevice for MCP2515<SPI> {
             Ok(_) => info!("Bitrate set!"),
             Err(_) => error!("Failed to set bitrate!!!"),
         };
-        match self.set_mode(OpMode::Normal) {
-            Ok(_) => info!("Switching to Normal Mode"),
-            Err(_) => error!("Failed to switch to Normal Mode"),
-        }
     }
 
     fn set_filter(&mut self, id: Id) {
@@ -69,15 +65,21 @@ impl<SPI: SpiDevice> CanDevice for MCP2515<SPI> {
     }
 
     fn open(&mut self) {
-        todo!();
+        match self.set_mode(OpMode::Normal) {
+            Ok(_) => info!("CAN device open, mode normal."),
+            Err(_) => error!("Failed to open, mode normal."),
+        }
     }
 
     fn close(&mut self) {
-        todo!();
+        info!("CAN device close, nothing to do.");
     }
 
     fn listen_only(&mut self) {
-        todo!();
+        match self.set_mode(OpMode::ListenOnly) {
+            Ok(_) => info!("CAN device open, mode listen only."),
+            Err(_) => error!("Failed to open, mode listen only."),
+        }
     }
 }
 


### PR DESCRIPTION
Changes:
- The slCAN command FilterMask was not setting the mask.
- The open(), close() and listen_only() methods that had todo!() have been implemented. It now works with slcand and ip in Linux.
